### PR TITLE
Remove autoupdate strategy

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -60,9 +60,6 @@ ram.runtime = "50M"
     url = "https://download.invoiceninja.com/ninja-v4.5.50.zip"
     sha256 = "54ba1cd5747892b346684294dc3512541dc86c6d67bc28126bcd3bf6c206b0d2"
 
-    autoupdate.upstream = "https://github.com/invoiceninja/invoiceninja"
-    autoupdate.strategy = "latest_github_release"
-
     [resources.sources.phantomjs]
     url = "https://github.com/ariya/phantomjs/archive/0a0b0facb16acfbabb7804822ecaf4f4b9dce3d2.tar.gz"
     sha256 = "5fa3d4be85f3aecc066fa2d5bbf55f856957f4fb329da52ec63398195ad9ceaa"


### PR DESCRIPTION
## Problem

This invoiceninja package refers to InvoiceNinja version 4 which was frozen at 4.5.50 and won't be updated anymore in the future. Also see https://github.com/YunoHost/apps/pull/1710 

As currently there is an autoupdate strategy defined this leads to many PRs which won't ever be merged and unnecessarily consume resources, see https://github.com/YunoHost-Apps/invoiceninja_ynh/pulls .

## Solution

Remove autoupdate strategy from `manifest.toml`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
